### PR TITLE
Add API key management endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ The API will be available at `http://localhost:3000`. API documentation is at `h
 | GET | `/sessions/devices` | List known devices |
 | POST | `/sessions/devices/:id/trust` | Trust a device |
 
+### API Keys
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/api-keys` | Create a new API key |
+| GET | `/api-keys` | List your API keys |
+| GET | `/api-keys/:id` | Get API key details |
+| POST | `/api-keys/:id/revoke` | Revoke an API key |
+| DELETE | `/api-keys/:id` | Delete an API key |
+
 ### Admin
 | Method | Endpoint | Description |
 |--------|----------|-------------|
@@ -166,17 +175,16 @@ This project is under active development. Core authentication features are funct
 ### What's Working
 - User registration, login, logout
 - JWT token refresh flow
-- Password reset (token generation)
+- Password reset (token generation + email delivery)
+- Email verification flow
 - MFA setup and verification
 - Session management
 - Role-based access control
+- API key management (create, list, revoke, delete)
 - Audit logging
 - Rate limiting
 
 ### Roadmap
-- [ ] Email service integration (SMTP for verification/reset emails)
-- [ ] Email verification flow
-- [ ] API key management endpoints
-- [ ] Expanded test coverage (sessions, admin, audit)
-- [ ] Password reset email delivery
+- [ ] API key rotation and key-based authentication
+- [ ] Expanded test coverage (sessions, admin, audit, API keys)
 - [ ] Account recovery options

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,7 @@ import { mfaRoutes } from './routes/mfa.routes.js';
 import { sessionRoutes } from './routes/session.routes.js';
 import { adminRoutes } from './routes/admin.routes.js';
 import { auditRoutes } from './routes/audit.routes.js';
+import { apiKeyRoutes } from './routes/apikey.routes.js';
 
 export async function buildApp(): Promise<FastifyInstance> {
   const app = Fastify({
@@ -110,6 +111,7 @@ export async function buildApp(): Promise<FastifyInstance> {
   await app.register(sessionRoutes, { prefix: '/sessions' });
   await app.register(adminRoutes, { prefix: '/admin' });
   await app.register(auditRoutes, { prefix: '/audit' });
+  await app.register(apiKeyRoutes, { prefix: '/api-keys' });
 
   // Error handling
   app.setErrorHandler(errorHandler);

--- a/src/routes/apikey.routes.ts
+++ b/src/routes/apikey.routes.ts
@@ -1,0 +1,134 @@
+import type { FastifyInstance } from 'fastify';
+import * as apiKeyService from '../services/apikey.service.js';
+import * as auditService from '../services/audit.service.js';
+import { authenticate, extractClientInfo } from '../middleware/auth.middleware.js';
+import { createApiKeySchema, apiKeyIdParamSchema } from '../utils/validators.js';
+import { AuditAction } from '../types/index.js';
+
+export async function apiKeyRoutes(fastify: FastifyInstance): Promise<void> {
+  // All API key routes require authentication
+  fastify.addHook('preHandler', authenticate);
+
+  // Create a new API key
+  fastify.post('/', async (request, reply) => {
+    const { name, permissions, expiresInDays } = createApiKeySchema.parse(request.body);
+    const { ipAddress, userAgent } = extractClientInfo(request);
+
+    const expiresAt = expiresInDays
+      ? new Date(Date.now() + expiresInDays * 24 * 60 * 60 * 1000)
+      : undefined;
+
+    const { apiKey, rawKey } = await apiKeyService.createApiKey(
+      request.user!.id,
+      name,
+      permissions,
+      expiresAt
+    );
+
+    await auditService.logAuthEvent(AuditAction.API_KEY_CREATED, {
+      userId: request.user!.id,
+      ipAddress,
+      userAgent,
+      metadata: { keyName: name, keyPrefix: apiKey.keyPrefix },
+    });
+
+    reply.code(201).send({
+      success: true,
+      data: {
+        apiKey,
+        rawKey,
+        message: 'Store this key securely — it will not be shown again',
+      },
+    });
+  });
+
+  // List all API keys for the user
+  fastify.get('/', async (request, reply) => {
+    const keys = await apiKeyService.listApiKeys(request.user!.id);
+
+    reply.send({
+      success: true,
+      data: { apiKeys: keys },
+    });
+  });
+
+  // Get a specific API key
+  fastify.get<{ Params: { id: string } }>('/:id', async (request, reply) => {
+    const { id } = apiKeyIdParamSchema.parse(request.params);
+
+    const apiKey = await apiKeyService.getApiKeyById(id, request.user!.id);
+
+    if (!apiKey) {
+      reply.code(404).send({
+        success: false,
+        error: {
+          code: 'NOT_FOUND',
+          message: 'API key not found',
+        },
+      });
+      return;
+    }
+
+    reply.send({
+      success: true,
+      data: { apiKey },
+    });
+  });
+
+  // Revoke an API key
+  fastify.post<{ Params: { id: string } }>('/:id/revoke', async (request, reply) => {
+    const { id } = apiKeyIdParamSchema.parse(request.params);
+    const { ipAddress, userAgent } = extractClientInfo(request);
+
+    const apiKey = await apiKeyService.revokeApiKey(id, request.user!.id);
+
+    if (!apiKey) {
+      reply.code(404).send({
+        success: false,
+        error: {
+          code: 'NOT_FOUND',
+          message: 'API key not found',
+        },
+      });
+      return;
+    }
+
+    await auditService.logAuthEvent(AuditAction.API_KEY_REVOKED, {
+      userId: request.user!.id,
+      ipAddress,
+      userAgent,
+      metadata: { keyName: apiKey.name, keyPrefix: apiKey.keyPrefix },
+    });
+
+    reply.send({
+      success: true,
+      data: {
+        apiKey,
+        message: 'API key revoked',
+      },
+    });
+  });
+
+  // Delete an API key permanently
+  fastify.delete<{ Params: { id: string } }>('/:id', async (request, reply) => {
+    const { id } = apiKeyIdParamSchema.parse(request.params);
+
+    const deleted = await apiKeyService.deleteApiKey(id, request.user!.id);
+
+    if (!deleted) {
+      reply.code(404).send({
+        success: false,
+        error: {
+          code: 'NOT_FOUND',
+          message: 'API key not found',
+        },
+      });
+      return;
+    }
+
+    reply.send({
+      success: true,
+      data: { message: 'API key deleted' },
+    });
+  });
+}

--- a/src/services/apikey.service.ts
+++ b/src/services/apikey.service.ts
@@ -1,0 +1,121 @@
+import { getPrismaClient } from '../config/database.js';
+import { generateApiKey, hashToken } from '../utils/crypto.js';
+import type { ApiKey } from '@prisma/client';
+
+const prisma = getPrismaClient();
+
+export interface ApiKeyInfo {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  permissions: string[];
+  lastUsedAt: Date | null;
+  expiresAt: Date | null;
+  revokedAt: Date | null;
+  createdAt: Date;
+}
+
+export async function createApiKey(
+  userId: string,
+  name: string,
+  permissions: string[],
+  expiresAt?: Date
+): Promise<{ apiKey: ApiKeyInfo; rawKey: string }> {
+  const { key, prefix, hash } = generateApiKey();
+
+  const created = await prisma.apiKey.create({
+    data: {
+      userId,
+      name,
+      keyHash: hash,
+      keyPrefix: prefix,
+      permissions,
+      expiresAt: expiresAt ?? null,
+    },
+  });
+
+  return {
+    apiKey: toApiKeyInfo(created),
+    rawKey: key,
+  };
+}
+
+export async function listApiKeys(userId: string): Promise<ApiKeyInfo[]> {
+  const keys = await prisma.apiKey.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return keys.map(toApiKeyInfo);
+}
+
+export async function getApiKeyById(id: string, userId: string): Promise<ApiKeyInfo | null> {
+  const key = await prisma.apiKey.findFirst({
+    where: { id, userId },
+  });
+
+  return key ? toApiKeyInfo(key) : null;
+}
+
+export async function revokeApiKey(id: string, userId: string): Promise<ApiKeyInfo | null> {
+  const key = await prisma.apiKey.findFirst({
+    where: { id, userId },
+  });
+
+  if (!key) return null;
+  if (key.revokedAt) return toApiKeyInfo(key);
+
+  const updated = await prisma.apiKey.update({
+    where: { id },
+    data: { revokedAt: new Date() },
+  });
+
+  return toApiKeyInfo(updated);
+}
+
+export async function deleteApiKey(id: string, userId: string): Promise<boolean> {
+  const key = await prisma.apiKey.findFirst({
+    where: { id, userId },
+  });
+
+  if (!key) return false;
+
+  await prisma.apiKey.delete({ where: { id } });
+  return true;
+}
+
+export async function validateApiKey(rawKey: string): Promise<{ userId: string; permissions: string[] } | null> {
+  const hash = hashToken(rawKey);
+
+  const key = await prisma.apiKey.findUnique({
+    where: { keyHash: hash },
+  });
+
+  if (!key) return null;
+  if (key.revokedAt) return null;
+  if (key.expiresAt && key.expiresAt < new Date()) return null;
+
+  // Update last used timestamp
+  await prisma.apiKey.update({
+    where: { id: key.id },
+    data: { lastUsedAt: new Date() },
+  });
+
+  return {
+    userId: key.userId,
+    permissions: key.permissions,
+  };
+}
+
+function toApiKeyInfo(key: ApiKey): ApiKeyInfo {
+  return {
+    id: key.id,
+    name: key.name,
+    keyPrefix: key.keyPrefix,
+    permissions: key.permissions,
+    lastUsedAt: key.lastUsedAt,
+    expiresAt: key.expiresAt,
+    revokedAt: key.revokedAt,
+    createdAt: key.createdAt,
+  };
+}

--- a/src/services/audit.service.ts
+++ b/src/services/audit.service.ts
@@ -1,15 +1,15 @@
 import { getPrismaClient } from '../config/database.js';
 import type { AuditAction, AuditLogEntry, PaginatedResponse } from '../types/index.js';
-import type { AuditLog } from '@prisma/client';
+import type { AuditLog, Prisma } from '@prisma/client';
 
 const prisma = getPrismaClient();
 
 export async function createAuditLog(entry: AuditLogEntry): Promise<AuditLog> {
   return prisma.auditLog.create({
     data: {
-      userId: entry.userId,
+      ...(entry.userId ? { userId: entry.userId } : {}),
       action: entry.action,
-      details: entry.details,
+      details: entry.details as unknown as Prisma.InputJsonValue,
       ipAddress: entry.ipAddress,
       userAgent: entry.userAgent,
     },
@@ -45,7 +45,7 @@ export async function logAuthEvent(
 
   await createAuditLog({
     action,
-    userId: options.userId,
+    ...(options.userId ? { userId: options.userId } : {}),
     details,
     ipAddress: options.ipAddress,
     userAgent: options.userAgent,
@@ -53,10 +53,10 @@ export async function logAuthEvent(
 }
 
 export async function getAuditLogs(options: {
-  userId?: string;
-  action?: string;
-  startDate?: Date;
-  endDate?: Date;
+  userId?: string | undefined;
+  action?: string | undefined;
+  startDate?: Date | undefined;
+  endDate?: Date | undefined;
   page: number;
   limit: number;
 }): Promise<PaginatedResponse<AuditLog>> {
@@ -113,10 +113,10 @@ export async function getUserActivityLogs(
 }
 
 export async function exportAuditLogs(options: {
-  userId?: string;
-  action?: string;
-  startDate?: Date;
-  endDate?: Date;
+  userId?: string | undefined;
+  action?: string | undefined;
+  startDate?: Date | undefined;
+  endDate?: Date | undefined;
 }): Promise<AuditLog[]> {
   const where: Record<string, unknown> = {};
 

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -478,7 +478,7 @@ export async function requestPasswordReset(
   // Always log the attempt, even if user doesn't exist (for security)
   await auditService.logAuthEvent(AuditAction.PASSWORD_RESET_REQUEST, {
     email,
-    userId: user?.id,
+    ...(user ? { userId: user.id } : {}),
     ipAddress,
     userAgent,
   });
@@ -705,7 +705,7 @@ async function recordFailedLogin(
   // Log the failed attempt
   await auditService.logAuthEvent(AuditAction.LOGIN_FAILURE, {
     email,
-    userId,
+    ...(userId ? { userId } : {}),
     ipAddress,
     userAgent,
   });

--- a/src/services/session.service.ts
+++ b/src/services/session.service.ts
@@ -22,7 +22,7 @@ export async function createSession(
     data: {
       userId,
       refreshToken: refreshTokenHash,
-      deviceId,
+      deviceId: deviceId ?? null,
       ipAddress,
       userAgent,
       expiresAt,

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -230,12 +230,14 @@ export async function createRole(
   return prisma.role.create({
     data: {
       name,
-      description,
-      permissions: permissionIds
+      description: description ?? null,
+      ...(permissionIds
         ? {
-            connect: permissionIds.map((id) => ({ id })),
+            permissions: {
+              connect: permissionIds.map((id) => ({ id })),
+            },
           }
-        : undefined,
+        : {}),
     },
     include: {
       permissions: true,
@@ -257,6 +259,6 @@ export async function getPermissions() {
 
 export async function createPermission(name: string, description?: string) {
   return prisma.permission.create({
-    data: { name, description },
+    data: { name, description: description ?? null },
   });
 }

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -84,6 +84,16 @@ export const resendVerificationSchema = z.object({
   email: emailSchema,
 });
 
+export const createApiKeySchema = z.object({
+  name: z.string().min(1, 'Name is required').max(100, 'Name must not exceed 100 characters'),
+  permissions: z.array(z.string()).default([]),
+  expiresInDays: z.number().int().min(1).max(365).optional(),
+});
+
+export const apiKeyIdParamSchema = z.object({
+  id: z.string().cuid('Invalid API key ID'),
+});
+
 export const auditLogQuerySchema = z.object({
   userId: z.string().cuid().optional(),
   action: z.string().optional(),
@@ -103,4 +113,5 @@ export type ChangePasswordInput = z.infer<typeof changePasswordSchema>;
 export type PaginationInput = z.infer<typeof paginationSchema>;
 export type EmailVerificationInput = z.infer<typeof emailVerificationSchema>;
 export type ResendVerificationInput = z.infer<typeof resendVerificationSchema>;
+export type CreateApiKeyInput = z.infer<typeof createApiKeySchema>;
 export type AuditLogQueryInput = z.infer<typeof auditLogQuerySchema>;


### PR DESCRIPTION
## Summary
- Add API key service with create, list, get, revoke, and delete operations
- Add validation schemas for API key creation and ID params
- Add authenticated routes under `/api-keys` with audit logging
- Keys are SHA-256 hashed before storage, raw key shown only on creation
- Fix strict TypeScript errors across services (exactOptionalPropertyTypes compliance)

Closes #3

## Test plan
- [ ] Create an API key and verify the raw key is returned once
- [ ] List keys and confirm raw key is not exposed
- [ ] Revoke a key and verify it can't be validated
- [ ] Delete a key permanently
- [ ] Verify audit logs capture create/revoke events